### PR TITLE
feat(skills::plugin): Add Claude Code plugin marketplace config for scrolls skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "sugatoray",
+  "owner": {
+    "name": "Sugato Ray",
+    "url": "https://github.com/sugatoray"
+  },
+  "description": "Sugato Ray's curated agent skills, as installable Claude Code plugins.",
+  "plugins": [
+    {
+      "name": "scrolls-skills",
+      "source": "./",
+      "description": "Scrolls: a git-native markdown system for agentic memory that persists project state across sessions and agents (/scrolls-setup, /scrolls-update, /scrolls-hide, /scrolls-unhide, /scrolls-help).",
+      "category": "productivity",
+      "keywords": [
+        "memory",
+        "agentic-memory",
+        "docs",
+        "handoff",
+        "productivity",
+        "scrolls"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,10 +5,13 @@
     "url": "https://github.com/sugatoray"
   },
   "description": "Sugato Ray's curated agent skills, as installable Claude Code plugins.",
+  "metadata": {
+    "pluginRoot": "./skills"
+  },
   "plugins": [
     {
       "name": "scrolls-skills",
-      "source": "./",
+      "source": "./scrolls",
       "description": "Scrolls: a git-native markdown system for agentic memory that persists project state across sessions and agents (/scrolls-setup, /scrolls-update, /scrolls-hide, /scrolls-unhide, /scrolls-help).",
       "category": "productivity",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "scrolls-skills",
+  "version": "2.1.0",
+  "description": "Scrolls: a git-native markdown system for agentic memory that persists project state across sessions and agents. Five commands manage docs/.scrolls/ — setup, update, hide, unhide, and a help reference.",
+  "author": {
+    "name": "Sugato Ray",
+    "url": "https://github.com/sugatoray"
+  },
+  "homepage": "https://github.com/sugatoray/aiskills",
+  "repository": "https://github.com/sugatoray/aiskills",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "agentic-memory",
+    "docs",
+    "handoff",
+    "productivity",
+    "scrolls"
+  ],
+  "skills": [
+    "./skills/scrolls/scrolls-setup",
+    "./skills/scrolls/scrolls-update",
+    "./skills/scrolls/scrolls-hide",
+    "./skills/scrolls/scrolls-unhide",
+    "./skills/scrolls/scrolls-help"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -10,29 +10,25 @@ Scrolls are a system of git-native markdown files, that together provide your pr
 
 **Installation**:
 
-Two ways in. **The Claude Code plugin** installs the whole family as a
-managed, read-only bundle from this repo's marketplace. **`npx skills`**
-copies editable skill files into your project so you can hack on them.
-Pick one — installing both leaves you with every skill twice.
-
-<details>
-<summary><strong>Claude Code plugin</strong></summary>
-
-```
-/plugin marketplace add sugatoray/aiskills
-/plugin install scrolls-skills@sugatoray
-```
-
-</details>
-
-<details>
-<summary><strong>Codex, and other agents (or editable copies in Claude Code)</strong></summary>
-
-Choose the skills by the name: `scrolls-*` and install interactively.
+Install with `npx skills` (RECOMMENDED). It works with Claude Code,
+Codex, and other agents, and copies editable skill files into your
+project. Choose skills by name (`scrolls-*`) and install interactively.
 
 ```sh
 npx skills add sugatoray/aiskills               # project-level
 npx skills add sugatoray/aiskills --global      # user-level (RECOMMENDED)
+```
+
+<details>
+<summary><strong>Alternate: Claude Code plugin</strong></summary>
+
+Installs the whole family as a managed, read-only bundle from this
+repo's marketplace. Installing both this and `npx skills` leaves you
+with every skill twice — pick one.
+
+```
+/plugin marketplace add sugatoray/aiskills
+/plugin install scrolls-skills@sugatoray
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -10,12 +10,32 @@ Scrolls are a system of git-native markdown files, that together provide your pr
 
 **Installation**:
 
+Two ways in. **The Claude Code plugin** installs the whole family as a
+managed, read-only bundle from this repo's marketplace. **`npx skills`**
+copies editable skill files into your project so you can hack on them.
+Pick one — installing both leaves you with every skill twice.
+
+<details>
+<summary><strong>Claude Code plugin</strong></summary>
+
+```
+/plugin marketplace add sugatoray/aiskills
+/plugin install scrolls-skills@sugatoray
+```
+
+</details>
+
+<details>
+<summary><strong>Codex, and other agents (or editable copies in Claude Code)</strong></summary>
+
 Choose the skills by the name: `scrolls-*` and install interactively.
 
 ```sh
 npx skills add sugatoray/aiskills               # project-level
 npx skills add sugatoray/aiskills --global      # user-level (RECOMMENDED)
 ```
+
+</details>
 
 **Getting Started**:
 

--- a/skills/scrolls/.claude-plugin/plugin.json
+++ b/skills/scrolls/.claude-plugin/plugin.json
@@ -18,10 +18,10 @@
     "scrolls"
   ],
   "skills": [
-    "./skills/scrolls/scrolls-setup",
-    "./skills/scrolls/scrolls-update",
-    "./skills/scrolls/scrolls-hide",
-    "./skills/scrolls/scrolls-unhide",
-    "./skills/scrolls/scrolls-help"
+    "./scrolls-setup",
+    "./scrolls-update",
+    "./scrolls-hide",
+    "./scrolls-unhide",
+    "./scrolls-help"
   ]
 }

--- a/skills/scrolls/meta/MAINTAINERS.md
+++ b/skills/scrolls/meta/MAINTAINERS.md
@@ -67,6 +67,56 @@ not a second copy. Never duplicate skill content into `src/`; if the
 pointer's install commands or target-folder note go stale, fix them in
 place rather than growing a parallel source of truth.
 
+## Claude Code plugin manifest (`.claude-plugin/plugin.json`)
+
+**Design choice**: this manifest lives inside `skills/scrolls/`, not at
+the repo root. The repo root only holds `.claude-plugin/marketplace.json`
+(the catalog), with `metadata.pluginRoot: "./skills"` set so each plugin
+entry's `source` can just be `"./<group>"`. Scrolls's entry is
+`"./scrolls"`, resolving to `skills/scrolls/.claude-plugin/plugin.json`.
+The point of this layout: any future skill-group folder that lands next
+to `skills/scrolls/` (e.g. `skills/<newgroup>/`) gets its own
+`.claude-plugin/plugin.json` inside its own directory plus one new
+one-line entry in the root `marketplace.json` — never a second manifest
+competing for the repo root, and no other group's skills ever get pulled
+into an unrelated install.
+
+**Keep it in sync — every time**:
+
+- **Version**: `plugin.json`'s top-level `"version"` must match the
+  family's lockstep `metadata.version` (see "Versioning" above) exactly.
+  Bump it in the same commit as any family-wide version bump — a
+  mismatched plugin version is the same class of bug as a mismatched
+  skill version.
+- **New skill published**: add its `./scrolls-<name>` path to the
+  `"skills"` array in the same commit that adds the skill directory.
+- **Skill deprecated/deactivated**: when a skill's `SKILL.md` is renamed
+  to `SKILL.md.deprecated`, `SKILL.md.deactivated`, or `SKILL.md.inactive`
+  (see below), remove that skill's entry from the `"skills"` array in the
+  same commit. The Claude Code plugin loader already silently drops a
+  skill whose directory has no file literally named `SKILL.md` — verified
+  with `claude --plugin-dir <path> plugin details <name>`, which reported
+  4 skills in the component inventory instead of 5 the moment one
+  `SKILL.md` was renamed away, with no warning from `claude plugin
+  validate` either, `--strict` or not. So a stale entry left in the array
+  costs nothing functionally, but it's still wrong: anyone reading
+  `plugin.json` to see what ships would be misled into thinking a
+  deactivated skill is still installed. Keep the array as the accurate
+  list of what's live, not a superset of it.
+
+**Renaming convention that discards a skill from installing**: the
+loader's discovery rule is an exact match on the filename `SKILL.md`
+inside a skill directory — nothing else. Any rename off that exact name
+is sufficient by itself to drop the skill from both `/plugin` installs
+and the `skills/` auto-discovery convention, independent of whatever
+suffix is chosen. This repo's convention is `SKILL.md.deprecated` /
+`SKILL.md.deactivated` / `SKILL.md.inactive` (pick whichever best states
+why it's off), because it keeps the file sitting right next to its own
+skill directory, keeps its content one `mv` away from being live again,
+and reads clearly in a directory listing — but the mechanism that
+actually makes it inert is simply "the file is no longer named
+`SKILL.md`," not the specific suffix used.
+
 ## Installing for local testing
 
 See `src/scrolls/CLAUDE.md` for the tested `npx skills add


### PR DESCRIPTION
Adds .claude-plugin/marketplace.json and plugin.json so the scrolls-*
skills under skills/scrolls/ can be installed as a Claude Code plugin
(/plugin marketplace add sugatoray/aiskills), alongside the existing
npx skills install path. Modeled on mattpocock/skills.

Co-Authored-By: Claude <noreply@anthropic.com>
