### PR TITLE
Add frontmatter validation guidance to MAINTAINERS docs

### DIFF
--- a/skills/newsletters/newsletter-ai/meta/MAINTAINERS.md
+++ b/skills/newsletters/newsletter-ai/meta/MAINTAINERS.md
@@ -420,6 +420,19 @@ When adding a new item content-shape (beyond `body`/`facts`/`table`/
 implementation. The same applies to `builder/` behavior changes: write
 or extend the failing test in `tests/` first.
 
+## Frontmatter validation
+
+Run `yamllint --strict` against `../SKILL.md`'s frontmatter every time this
+skill is updated — it catches unquoted URLs, trailing whitespace, and other
+formatting slips before they land. Extract the block between the two `---`
+markers and lint it (`line-length`/`document-start` disabled since prose
+descriptions and bare `SKILL.md` frontmatter both fail those on purpose):
+
+```
+awk '/^---$/{c++; if(c==2){exit}} c==1' ../SKILL.md | \
+  yamllint --strict -d "{extends: default, rules: {line-length: disable, document-start: disable}}" -
+```
+
 ## Versioning
 
 Bump `metadata.version` in `../SKILL.md`'s frontmatter when something

--- a/skills/newsletters/newsletter-ai/meta/MAINTAINERS.md
+++ b/skills/newsletters/newsletter-ai/meta/MAINTAINERS.md
@@ -428,7 +428,7 @@ formatting slips before they land. Extract the block between the two `---`
 markers and lint it (`line-length`/`document-start` disabled since prose
 descriptions and bare `SKILL.md` frontmatter both fail those on purpose):
 
-```
+```bash
 awk '/^---$/{c++; if(c==2){exit}} c==1' ../SKILL.md | \
   yamllint --strict -d "{extends: default, rules: {line-length: disable, document-start: disable}}" -
 ```

--- a/skills/scrolls/scrolls-help/SKILL.md
+++ b/skills/scrolls/scrolls-help/SKILL.md
@@ -10,7 +10,6 @@ metadata:
     author: sugatoray
     version: "2.1.0"
     source_url: "https://github.com/sugatoray/aiskills/tree/master/skills/scrolls/scrolls-help"
-    
 ---
 
 # Scrolls help

--- a/skills/scrolls/scrolls-help/meta/MAINTAINERS.md
+++ b/skills/scrolls/scrolls-help/meta/MAINTAINERS.md
@@ -47,7 +47,7 @@ formatting slips before they land. Extract the block between the two `---`
 markers and lint it (`line-length`/`document-start` disabled since prose
 descriptions and bare `SKILL.md` frontmatter both fail those on purpose):
 
-```
+```bash
 awk '/^---$/{c++; if(c==2){exit}} c==1' ../SKILL.md | \
   yamllint --strict -d "{extends: default, rules: {line-length: disable, document-start: disable}}" -
 ```

--- a/skills/scrolls/scrolls-help/meta/MAINTAINERS.md
+++ b/skills/scrolls/scrolls-help/meta/MAINTAINERS.md
@@ -39,6 +39,19 @@ pwsh tests/test_open_help.ps1   # where pwsh is available
 Covers: URL/PID reporting, the server actually answering a real request,
 `--stop`, and the idle-timeout auto-shutdown.
 
+## Frontmatter validation
+
+Run `yamllint --strict` against `../SKILL.md`'s frontmatter every time this
+skill is updated — it catches unquoted URLs, trailing whitespace, and other
+formatting slips before they land. Extract the block between the two `---`
+markers and lint it (`line-length`/`document-start` disabled since prose
+descriptions and bare `SKILL.md` frontmatter both fail those on purpose):
+
+```
+awk '/^---$/{c++; if(c==2){exit}} c==1' ../SKILL.md | \
+  yamllint --strict -d "{extends: default, rules: {line-length: disable, document-start: disable}}" -
+```
+
 ## Versioning
 
 Bump `metadata.version` in `../SKILL.md`'s frontmatter when something visible

--- a/skills/scrolls/scrolls-hide/meta/MAINTAINERS.md
+++ b/skills/scrolls/scrolls-hide/meta/MAINTAINERS.md
@@ -24,6 +24,19 @@ bash tests/test_hide.sh
 pwsh tests/test_hide.ps1   # where pwsh is available
 ```
 
+## Frontmatter validation
+
+Run `yamllint --strict` against `../SKILL.md`'s frontmatter every time this
+skill is updated — it catches unquoted URLs, trailing whitespace, and other
+formatting slips before they land. Extract the block between the two `---`
+markers and lint it (`line-length`/`document-start` disabled since prose
+descriptions and bare `SKILL.md` frontmatter both fail those on purpose):
+
+```
+awk '/^---$/{c++; if(c==2){exit}} c==1' ../SKILL.md | \
+  yamllint --strict -d "{extends: default, rules: {line-length: disable, document-start: disable}}" -
+```
+
 ## Versioning
 
 Bump `metadata.version` in `../SKILL.md`'s frontmatter when something

--- a/skills/scrolls/scrolls-hide/meta/MAINTAINERS.md
+++ b/skills/scrolls/scrolls-hide/meta/MAINTAINERS.md
@@ -32,7 +32,7 @@ formatting slips before they land. Extract the block between the two `---`
 markers and lint it (`line-length`/`document-start` disabled since prose
 descriptions and bare `SKILL.md` frontmatter both fail those on purpose):
 
-```
+```bash
 awk '/^---$/{c++; if(c==2){exit}} c==1' ../SKILL.md | \
   yamllint --strict -d "{extends: default, rules: {line-length: disable, document-start: disable}}" -
 ```

--- a/skills/scrolls/scrolls-setup/SKILL.md
+++ b/skills/scrolls/scrolls-setup/SKILL.md
@@ -9,7 +9,7 @@ metadata:
     type: skill
     author: sugatoray
     version: "2.1.0"
-    source_url: https://github.com/sugatoray/aiskills/tree/master/skills/scrolls/scrolls-setup
+    source_url: "https://github.com/sugatoray/aiskills/tree/master/skills/scrolls/scrolls-setup"
 ---
 
 # Setting up docs/.scrolls/

--- a/skills/scrolls/scrolls-setup/meta/MAINTAINERS.md
+++ b/skills/scrolls/scrolls-setup/meta/MAINTAINERS.md
@@ -38,7 +38,7 @@ formatting slips before they land. Extract the block between the two `---`
 markers and lint it (`line-length`/`document-start` disabled since prose
 descriptions and bare `SKILL.md` frontmatter both fail those on purpose):
 
-```
+```bash
 awk '/^---$/{c++; if(c==2){exit}} c==1' ../SKILL.md | \
   yamllint --strict -d "{extends: default, rules: {line-length: disable, document-start: disable}}" -
 ```

--- a/skills/scrolls/scrolls-setup/meta/MAINTAINERS.md
+++ b/skills/scrolls/scrolls-setup/meta/MAINTAINERS.md
@@ -30,6 +30,19 @@ script and no `tests/` — file creation goes through Read/Write/Edit tools
 directly at invocation time, not a script, so there's nothing to
 regression-test the way the others do.
 
+## Frontmatter validation
+
+Run `yamllint --strict` against `../SKILL.md`'s frontmatter every time this
+skill is updated — it catches unquoted URLs, trailing whitespace, and other
+formatting slips before they land. Extract the block between the two `---`
+markers and lint it (`line-length`/`document-start` disabled since prose
+descriptions and bare `SKILL.md` frontmatter both fail those on purpose):
+
+```
+awk '/^---$/{c++; if(c==2){exit}} c==1' ../SKILL.md | \
+  yamllint --strict -d "{extends: default, rules: {line-length: disable, document-start: disable}}" -
+```
+
 ## Versioning
 
 Bump `metadata.version` in `../SKILL.md`'s frontmatter when something

--- a/skills/scrolls/scrolls-unhide/meta/MAINTAINERS.md
+++ b/skills/scrolls/scrolls-unhide/meta/MAINTAINERS.md
@@ -24,6 +24,19 @@ bash tests/test_unhide.sh
 pwsh tests/test_unhide.ps1   # where pwsh is available
 ```
 
+## Frontmatter validation
+
+Run `yamllint --strict` against `../SKILL.md`'s frontmatter every time this
+skill is updated — it catches unquoted URLs, trailing whitespace, and other
+formatting slips before they land. Extract the block between the two `---`
+markers and lint it (`line-length`/`document-start` disabled since prose
+descriptions and bare `SKILL.md` frontmatter both fail those on purpose):
+
+```
+awk '/^---$/{c++; if(c==2){exit}} c==1' ../SKILL.md | \
+  yamllint --strict -d "{extends: default, rules: {line-length: disable, document-start: disable}}" -
+```
+
 ## Versioning
 
 Bump `metadata.version` in `../SKILL.md`'s frontmatter when something

--- a/skills/scrolls/scrolls-unhide/meta/MAINTAINERS.md
+++ b/skills/scrolls/scrolls-unhide/meta/MAINTAINERS.md
@@ -32,7 +32,7 @@ formatting slips before they land. Extract the block between the two `---`
 markers and lint it (`line-length`/`document-start` disabled since prose
 descriptions and bare `SKILL.md` frontmatter both fail those on purpose):
 
-```
+```bash
 awk '/^---$/{c++; if(c==2){exit}} c==1' ../SKILL.md | \
   yamllint --strict -d "{extends: default, rules: {line-length: disable, document-start: disable}}" -
 ```

--- a/skills/scrolls/scrolls-update/meta/MAINTAINERS.md
+++ b/skills/scrolls/scrolls-update/meta/MAINTAINERS.md
@@ -40,7 +40,7 @@ formatting slips before they land. Extract the block between the two `---`
 markers and lint it (`line-length`/`document-start` disabled since prose
 descriptions and bare `SKILL.md` frontmatter both fail those on purpose):
 
-```
+```bash
 awk '/^---$/{c++; if(c==2){exit}} c==1' ../SKILL.md | \
   yamllint --strict -d "{extends: default, rules: {line-length: disable, document-start: disable}}" -
 ```

--- a/skills/scrolls/scrolls-update/meta/MAINTAINERS.md
+++ b/skills/scrolls/scrolls-update/meta/MAINTAINERS.md
@@ -32,6 +32,19 @@ bash tests/test_session_diff.sh
 pwsh tests/test_session_diff.ps1   # where pwsh is available
 ```
 
+## Frontmatter validation
+
+Run `yamllint --strict` against `../SKILL.md`'s frontmatter every time this
+skill is updated — it catches unquoted URLs, trailing whitespace, and other
+formatting slips before they land. Extract the block between the two `---`
+markers and lint it (`line-length`/`document-start` disabled since prose
+descriptions and bare `SKILL.md` frontmatter both fail those on purpose):
+
+```
+awk '/^---$/{c++; if(c==2){exit}} c==1' ../SKILL.md | \
+  yamllint --strict -d "{extends: default, rules: {line-length: disable, document-start: disable}}" -
+```
+
 ## Versioning
 
 Bump `metadata.version` in `../SKILL.md`'s frontmatter when something


### PR DESCRIPTION
## Summary
This PR adds standardized frontmatter validation documentation across multiple skill MAINTAINERS files and fixes YAML formatting issues in SKILL.md files.

## Key Changes
- **Documentation**: Added a new "Frontmatter validation" section to 6 MAINTAINERS.md files (newsletter-ai, scrolls-help, scrolls-hide, scrolls-setup, scrolls-unhide, scrolls-update) with instructions for running `yamllint --strict` against SKILL.md frontmatter
- **YAML Fixes**: 
  - Quoted the unquoted `source_url` in scrolls-setup/SKILL.md frontmatter
  - Removed trailing whitespace after `source_url` in scrolls-help/SKILL.md frontmatter

## Implementation Details
The validation guidance includes:
- A clear explanation of what yamllint catches (unquoted URLs, trailing whitespace, formatting issues)
- An `awk` command to extract the frontmatter block between `---` markers
- A yamllint configuration that disables `line-length` and `document-start` rules since prose descriptions and bare frontmatter intentionally violate those rules
- Consistent placement before the existing "Versioning" section in each MAINTAINERS.md file

This ensures maintainers validate frontmatter formatting before updates land, preventing common YAML formatting issues.
