### PR TITLE
Add Codex plugin manifest for scrolls skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ with every skill twice — pick one.
 
 </details>
 
+<details>
+<summary><strong>Alternate: Codex plugin</strong></summary>
+
+`skills/scrolls/.codex-plugin/plugin.json` packages the same five skills
+as a local Codex plugin. Self-serve publishing to the official Codex
+Plugin Directory isn't available yet, so install it from a clone:
+
+```sh
+git clone https://github.com/sugatoray/aiskills
+codex plugins install aiskills/skills/scrolls --dev
+```
+
+Installing both this and `npx skills` leaves you with every skill
+twice — pick one. Note: all five skills are explicit-command-only
+(`disable-model-invocation: true`), which fails Codex's own bundled
+plugin validator as of this writing — see
+[`skills/scrolls/meta/MAINTAINERS.md`](skills/scrolls/meta/MAINTAINERS.md)
+for the full caveat.
+
+</details>
+
 **Getting Started**:
 
 1. Initialize **Scorlls** persistent agentic memory.

--- a/skills/scrolls/.codex-plugin/plugin.json
+++ b/skills/scrolls/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "scrolls-skills",
+  "version": "2.1.0",
+  "description": "Scrolls: a git-native markdown system for agentic memory that persists project state across sessions and agents. Five commands manage docs/.scrolls/ — setup, update, hide, unhide, and a help reference.",
+  "author": {
+    "name": "Sugato Ray",
+    "url": "https://github.com/sugatoray"
+  },
+  "homepage": "https://github.com/sugatoray/aiskills",
+  "repository": "https://github.com/sugatoray/aiskills",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "agentic-memory",
+    "docs",
+    "handoff",
+    "productivity",
+    "scrolls"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Scrolls",
+    "shortDescription": "Git-native markdown memory that persists across sessions",
+    "longDescription": "Scrolls is a git-native markdown system for agentic memory that persists project state across sessions and agents. Five commands manage docs/.scrolls/: scrolls-setup scaffolds the memory files for a project that doesn't have them yet, scrolls-update keeps them current after every session, scrolls-hide/scrolls-unhide toggle between a dotfile-hidden and a visible folder name, and scrolls-help is a full example-driven reference.",
+    "developerName": "Sugato Ray",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/sugatoray/aiskills",
+    "defaultPrompt": [
+      "Set up a Scrolls memory system for this project.",
+      "Update Scrolls with what happened this session.",
+      "Show me the Scrolls help reference."
+    ],
+    "brandColor": "#7C3AED"
+  }
+}

--- a/skills/scrolls/CHANGELOG.md
+++ b/skills/scrolls/CHANGELOG.md
@@ -24,6 +24,21 @@ Versioning entry) — one shared number across the family, currently:
 | `scrolls-unhide` | 2.1.0 |
 | `scrolls-help` | 2.1.0 |
 
+## 2026-08-29 (docs, no version bump)
+
+- **Codex plugin manifest added.** `skills/scrolls/.codex-plugin/plugin.json`,
+  alongside the existing Claude Code `.claude-plugin/plugin.json`, so the
+  same five skills are discoverable as a Codex plugin. `skills/scrolls/skills/`
+  holds one symlink per skill pointing back at its real, un-duplicated
+  directory — Codex's plugin schema requires `"skills"` to resolve to a
+  directory literally named `skills/` under the plugin root. See
+  `meta/MAINTAINERS.md`'s new "Codex plugin manifest" section for the full
+  design rationale and a known caveat: all five skills set
+  `disable-model-invocation: true` on purpose (explicit-command-only),
+  which fails OpenAI's own bundled plugin validator (`validate_plugin.py`)
+  — left as-is deliberately rather than changing invocation behavior for
+  the sake of one packaging format.
+
 ## 2026-08-20 (docs, no version bump)
 
 - **Per-skill `README.md` added to all five `scrolls-*` skills.** Each

--- a/skills/scrolls/meta/MAINTAINERS.md
+++ b/skills/scrolls/meta/MAINTAINERS.md
@@ -117,6 +117,55 @@ and reads clearly in a directory listing — but the mechanism that
 actually makes it inert is simply "the file is no longer named
 `SKILL.md`," not the specific suffix used.
 
+## Codex plugin manifest (`.codex-plugin/plugin.json`)
+
+**Design choice**: mirrors the Claude Code plugin above — the manifest
+lives inside `skills/scrolls/`, not at the repo root, so this family
+never competes for a repo-root manifest with any future
+`skills/<newgroup>/` that adds its own `.codex-plugin/plugin.json` later.
+
+Codex's plugin schema (verified against `openai/codex`'s own
+`plugin-json-spec.md` and its bundled `validate_plugin.py`, both under
+`codex-rs/skills/src/assets/samples/plugin-creator/`) requires a
+`"skills"` field, when present, to resolve to exactly `skills` — a
+directory literally named `skills/` directly under the plugin root, not
+an arbitrary path. Since the five `scrolls-*` skill directories live as
+siblings of `.codex-plugin/` (matching the Claude Code layout, and never
+duplicated per "Where the installable artifacts live" below),
+`skills/scrolls/skills/` holds one symlink per skill
+(`scrolls-setup -> ../scrolls-setup`, etc.) rather than a real copy —
+zero content duplication, and each symlink resolves straight to that
+skill's real `SKILL.md`, scripts, and tests. Note for Windows
+maintainers: a `git clone` there needs `core.symlinks=true` (and
+Developer Mode/admin) for these five entries to check out as real
+symlinks rather than plain text files containing the link target — every
+other cross-platform concern in this family (the bundled scripts
+themselves) is unaffected, since only this `skills/` indirection uses
+symlinks at all.
+
+**Known caveat — `disable-model-invocation`**: `validate_plugin.py`
+rejects any skill whose frontmatter sets `disable-model-invocation` to
+anything other than `false`/absent. All five `scrolls-*` skills set it
+to `true` on purpose — explicit-`/scrolls-*`-command-only, matching each
+skill's own `agents/openai.yaml` (`policy.allow_implicit_invocation:
+false`) — so as of this writing this plugin will fail that validator,
+and possibly Codex's real plugin installer if it enforces the same rule
+(unconfirmed — `validate_plugin.py` is a bundled sample validator, not
+something run against this repo). This is a deliberate tradeoff, not an
+oversight: flipping the flag would let Codex (and Claude) trigger these
+skills without an explicit command, a real behavior change to the whole
+family, not something to change silently for one packaging format. Leave
+it as `true` unless a maintainer deliberately decides the family should
+allow implicit invocation everywhere — if that ever happens, update both
+this note and `../README.md`.
+
+**Keep it in sync — every time**, same as the Claude Code plugin's own
+rules above: version lockstep with `metadata.version`, add/remove a
+symlink in `skills/scrolls/skills/` in the same commit a skill is
+added/deprecated (mirroring the `"skills"` array update on the Claude
+side), and never let this manifest's `"version"` drift from the other
+one's.
+
 ## Installing for local testing
 
 See `src/scrolls/CLAUDE.md` for the tested `npx skills add

--- a/skills/scrolls/skills/scrolls-help
+++ b/skills/scrolls/skills/scrolls-help
@@ -1,0 +1,1 @@
+../scrolls-help

--- a/skills/scrolls/skills/scrolls-hide
+++ b/skills/scrolls/skills/scrolls-hide
@@ -1,0 +1,1 @@
+../scrolls-hide

--- a/skills/scrolls/skills/scrolls-setup
+++ b/skills/scrolls/skills/scrolls-setup
@@ -1,0 +1,1 @@
+../scrolls-setup

--- a/skills/scrolls/skills/scrolls-unhide
+++ b/skills/scrolls/skills/scrolls-unhide
@@ -1,0 +1,1 @@
+../scrolls-unhide

--- a/skills/scrolls/skills/scrolls-update
+++ b/skills/scrolls/skills/scrolls-update
@@ -1,0 +1,1 @@
+../scrolls-update


### PR DESCRIPTION
## Summary
This PR adds support for packaging the five scrolls skills as a Codex plugin, alongside the existing Claude Code plugin support. A new plugin manifest and symlink structure enable the same skills to be discoverable and installable via Codex.

## Key Changes

- **Added Codex plugin manifest** (`skills/scrolls/.codex-plugin/plugin.json`): Defines the scrolls skills family as a Codex plugin with metadata, interface configuration, and default prompts. Version locked at 2.1.0 to match the Claude Code plugin.

- **Created symlink indirection layer** (`skills/scrolls/skills/`): Five symlinks (`scrolls-setup`, `scrolls-update`, `scrolls-hide`, `scrolls-unhide`, `scrolls-help`) point back to their real directories. This satisfies Codex's schema requirement that the `"skills"` field resolve to a directory literally named `skills/` under the plugin root, while avoiding content duplication.

- **Updated documentation**:
  - `meta/MAINTAINERS.md`: New "Codex plugin manifest" section explaining the design rationale, symlink strategy, and a known caveat about `disable-model-invocation: true` failing Codex's bundled validator.
  - `README.md`: Added "Alternate: Codex plugin" installation instructions.
  - `CHANGELOG.md`: Documented the addition with full context on the design choices.

## Notable Implementation Details

- **Symlinks on Windows**: Requires `git clone` with `core.symlinks=true` and Developer Mode/admin privileges; documented for maintainers.

- **Deliberate validator caveat**: All five skills intentionally set `disable-model-invocation: true` (explicit-command-only, matching `agents/openai.yaml`). This fails OpenAI's own `validate_plugin.py`, but changing it would alter invocation behavior across the family — left as-is unless a maintainer explicitly decides to allow implicit invocation everywhere.

- **Version lockstep**: The manifest version (2.1.0) is kept in sync with the Claude Code plugin; future skill additions/deprecations require updating both the `"skills"` array and the symlink directory in the same commit.

https://claude.ai/code/session_01CTGEK2mBM4B6AseqNCxYuu